### PR TITLE
datasketch getRank spark implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ scala> df.where("Date between '2007-06-01' and '2010-01-01'").selectExpr("percen
 |      3.25|
 +----------+
 
+# Estimate rank directly from data
+>>> df.selectExpr("approx_rank_ex(Global_active_power, 3.0) AS rank").show()
++----+
+|rank|
++----+
+| 0.8|
++----+
+
+# Estimate rank (CDF) for a value from a merged sketch
+>>> df.selectExpr("approx_rank_estimate(merged, 3.0) AS rank").show()
++----+
+|rank|
++----+
+| 0.8|
++----+
+
 >>> df.selectExpr("approx_pmf_estimate(merged, 4) pmf").show(1, False)
 +--------------------------------------------------------------------------------------+
 |pmf                                                                                   |
@@ -318,4 +334,3 @@ you can use similar functions to the other two sketch ones:
 
 If you hit some bugs and have requests, please leave some comments on [Issues](https://github.com/maropu/datasketches-spark/issues)
 or Twitter ([@maropu](http://twitter.com/#!/maropu)).
-

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <maven.version>3.6.3</maven.version>
     <scala.version>2.12.18</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <datasketches.version>2.0.0</datasketches.version>
+    <datasketches.version>3.3.0</datasketches.version>
     <spark.version>3.5.3</spark.version>
     <spark.binary.version>3.5</spark.binary.version>
     <hadoop.version>3.2.0</hadoop.version>
@@ -430,7 +430,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.4.1</version>
           <executions>
             <execution>
             <id>jar-with-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,11 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.6.3</maven.version>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.18</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <datasketches.version>2.0.0</datasketches.version>
-    <spark.version>3.2.0</spark.version>
-    <spark.binary.version>3.2</spark.binary.version>
+    <spark.version>3.5.3</spark.version>
+    <spark.binary.version>3.5</spark.binary.version>
     <hadoop.version>3.2.0</hadoop.version>
     <hadoop.binary.version>3.2</hadoop.binary.version>
     <scalatest.version>3.2.3</scalatest.version>
@@ -184,7 +184,8 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.2</version>
+        <!-- Newer plugin avoids NPEs seen with recent Maven/Java versions -->
+        <version>4.8.1</version>
         <executions>
           <execution>
             <id>eclipse-add-source</id>
@@ -442,6 +443,16 @@
               <outputDirectory>${project.parent.build.directory}</outputDirectory>
               <minimizeJar>false</minimizeJar>
               <createDependencyReducedPom>false</createDependencyReducedPom>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.datasketches</pattern>
+                  <shadedPattern>com.statsig.shaded.datasketches</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.datasketches.memory</pattern>
+                  <shadedPattern>com.statsig.shaded.datasketches.memory</shadedPattern>
+                </relocation>
+              </relocations>
               <artifactSet>
                 <includes></includes>
               </artifactSet>
@@ -452,4 +463,3 @@
     </plugins>
   </build>
 </project>
-

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/quantileSketches.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/quantileSketches.scala
@@ -180,6 +180,17 @@ trait BasePercentileEstimation extends ImplicitCastInputTypes {
   override def checkInputDataTypes(): TypeCheckResult = {
     // Validate the inputTypes
     val defaultCheck = super.checkInputDataTypes()
+    var hasOutOfRangePercentage = false
+    if (defaultCheck.isSuccess && percentages != null) {
+      var i = 0
+      while (i < percentages.length && !hasOutOfRangePercentage) {
+        val p = percentages(i)
+        if (p < 0.0 || p > 1.0) {
+          hasOutOfRangePercentage = true
+        }
+        i += 1
+      }
+    }
     if (defaultCheck.isFailure) {
       defaultCheck
     } else if (!percentageExpression.foldable) {
@@ -188,7 +199,7 @@ trait BasePercentileEstimation extends ImplicitCastInputTypes {
         s"but got $percentageExpression")
     } else if (percentages == null) {
       TypeCheckFailure("Percentage value must not be null")
-    } else if (percentages.exists(percentage => percentage < 0.0 || percentage > 1.0)) {
+    } else if (hasOutOfRangePercentage) {
       // percentages(s) must be in the range [0.0, 1.0]
       TypeCheckFailure("Percentage(s) must be between 0.0 and 1.0, " +
         s"but got $percentageExpression")

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/quantileSketches.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/quantileSketches.scala
@@ -86,6 +86,7 @@ trait BaseQuantileSketchImpl {
   def merge(other: BaseQuantileSketchImpl): Unit
   def getQuantiles(fractions: Array[Double]): Array[Double]
   def getPMF(numSplits: Int): Array[Double]
+  def getRank(v: Double): Double
   def serializeTo(): Array[Byte]
 }
 
@@ -102,6 +103,7 @@ class KllFloatsSketchImpl(_impl: jKllFloatsSketch) extends BaseQuantileSketchImp
     val splitPoints = (1 until numSplits).map(_ * splitSize).toArray
     _impl.getPMF(splitPoints)
   }
+  override def getRank(v: Double): Double = _impl.getRank(v.toFloat)
   override def serializeTo(): Array[Byte] = _impl.toByteArray
 }
 
@@ -118,6 +120,7 @@ class ReqSketchImpl(_impl: jReqSketch) extends BaseQuantileSketchImpl {
     val splitPoints = (1 until numSplits).map(_ * splitSize).toArray
     _impl.getPMF(splitPoints)
   }
+  override def getRank(v: Double): Double = _impl.getRank(v.toFloat)
   override def serializeTo(): Array[Byte] = _impl.toByteArray
 }
 
@@ -138,6 +141,7 @@ class MergeableSketchImpl(var _impl: UpdateDoublesSketch) extends BaseQuantileSk
     val splitPoints = (1 until numSplits).map(_ * splitSize).toArray
     _impl.getPMF(splitPoints)
   }
+  override def getRank(v: Double): Double = _impl.getRank(v)
   override def serializeTo(): Array[Byte] = _impl.toByteArray
 }
 
@@ -236,6 +240,17 @@ trait BaseQuantileSketchAggregate extends TypedImperativeAggregate[BaseQuantileS
   def implName: String
   def child: Expression
 
+  private def toFloatValue(v: AnyRef): Float = child.dataType match {
+    case ByteType => v.asInstanceOf[Byte].toFloat
+    case ShortType => v.asInstanceOf[Short].toFloat
+    case IntegerType => v.asInstanceOf[Int].toFloat
+    case LongType => v.asInstanceOf[Long].toFloat
+    case FloatType => v.asInstanceOf[Float]
+    case DoubleType => v.asInstanceOf[Double].toFloat
+    case d: DecimalType => v.asInstanceOf[Decimal].toFloat
+    case t => throw new IllegalStateException(s"Unexpected data type ${t.catalogString}")
+  }
+
   override def createAggregationBuffer(): BaseQuantileSketchImpl = {
     QuantileSketch(implName)
   }
@@ -247,12 +262,7 @@ trait BaseQuantileSketchAggregate extends TypedImperativeAggregate[BaseQuantileS
     val value = child.eval(input).asInstanceOf[AnyRef]
     // Ignore empty rows, for example: percentile_approx(null)
     if (value != null) {
-      // Convert the value to a float value
-      val floatValue = child.dataType match {
-        case n: NumericType => n.numeric.toFloat(value.asInstanceOf[n.InternalType])
-        case t => throw new IllegalStateException(s"Unexpected data type ${t.catalogString}")
-      }
-      buffer.update(floatValue)
+      buffer.update(toFloatValue(value))
     }
     buffer
   }
@@ -639,6 +649,177 @@ case class QuantileFromSketchState(
          |Object $percentile = $pf.apply($ar);
          |if ($percentile != null) {
          |  ${ev.value} = $castCode;
+         |} else {
+         |  ${ev.isNull} = true;
+         |}
+       """.stripMargin
+    })
+  }
+
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): Expression = {
+    copy(newLeft, newRight)
+  }
+}
+
+@ExpressionDescription(
+  usage = """
+    _FUNC_(col, value) - Returns the approximate rank in [0.0, 1.0] of `value` within the numeric
+      column `col`. The second parameter must be a constant numeric literal. The internal sketch
+      algorithm can be configured via `spark.sql.dataSketches.quantiles.defaultImpl`.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col, 1) FROM VALUES (1), (2), (3), (4) AS t(col);
+       0.25
+      > SELECT _FUNC_(col, 4) FROM VALUES (1), (2), (3), (4) AS t(col);
+       1.0
+  """,
+  group = "agg_funcs",
+  since = "3.1.2")
+case class RankFromData(
+    child: Expression,
+    valueExpression: Expression,
+    mutableAggBufferOffset: Int = 0,
+    inputAggBufferOffset: Int = 0,
+    implName: String = SQLConf.get.quantileSketchImpl)
+  extends BaseQuantileSketchAggregate with ImplicitCastInputTypes {
+
+  def this(child: Expression, valueExpression: Expression) = {
+    this(child, valueExpression, 0, 0)
+  }
+
+  override def prettyName: String = "approx_rank_ex"
+
+  override def children: Seq[Expression] = child :: valueExpression :: Nil
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): RankFromData =
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): RankFromData =
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+
+  override lazy val dataType: DataType = DoubleType
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(NumericType, NumericType)
+
+  // Returns null for empty inputs
+  override def nullable: Boolean = true
+
+  @transient
+  private lazy val rankValue: java.lang.Double = valueExpression.eval() match {
+    case null => null
+    case v: java.lang.Byte => v.doubleValue()
+    case v: java.lang.Short => v.doubleValue()
+    case v: java.lang.Integer => v.doubleValue()
+    case v: java.lang.Long => v.doubleValue()
+    case v: java.lang.Float => v.doubleValue()
+    case v: java.lang.Double => v
+    case v: Decimal => v.toDouble
+    case other =>
+      throw new IllegalStateException(
+        s"Unexpected data type ${valueExpression.dataType.catalogString} for rank value: $other")
+  }
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val defaultCheck = super.checkInputDataTypes()
+    if (defaultCheck.isFailure) {
+      defaultCheck
+    } else if (!valueExpression.foldable) {
+      TypeCheckFailure("The rank value must be a constant literal, " +
+        s"but got $valueExpression")
+    } else if (rankValue == null) {
+      TypeCheckFailure("Rank value must not be null")
+    } else {
+      TypeCheckSuccess
+    }
+  }
+
+  override def eval(buffer: BaseQuantileSketchImpl): Any = {
+    if (!buffer.isEmpty) {
+      buffer.getRank(rankValue)
+    } else {
+      null
+    }
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
+    super.legacyWithNewChildren(newChildren)
+}
+
+@ExpressionDescription(
+  usage = """
+    _FUNC_(col, value) - Computes an approximate rank in [0.0, 1.0] for the given `value`
+      from an input quantile sketch state. The input state should be the one that the
+      percentile sketch algorithm specified by `spark.sql.dataSketches.quantiles.defaultImpl`
+      generates.
+  """,
+  since = "3.1.2")
+case class RankFromSketchState(
+    child: Expression,
+    valueExpression: Expression,
+    implName: String)
+  extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant with Logging {
+
+  def this(child: Expression, valueExpression: Expression) = {
+    this(child, valueExpression, SQLConf.get.quantileSketchImpl)
+  }
+
+  override def prettyName: String = "approx_rank_estimate"
+  override def left: Expression = child
+  override def right: Expression = valueExpression
+
+  override val dataType: DataType = DoubleType
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType, NumericType)
+
+  // Returns null for empty inputs
+  override def nullable: Boolean = true
+
+  @transient
+  private lazy val toDouble: Any => Double = valueExpression.dataType match {
+    case ByteType => (v: Any) => v.asInstanceOf[Byte].toDouble
+    case ShortType => (v: Any) => v.asInstanceOf[Short].toDouble
+    case IntegerType => (v: Any) => v.asInstanceOf[Int].toDouble
+    case LongType => (v: Any) => v.asInstanceOf[Long].toDouble
+    case FloatType => (v: Any) => v.asInstanceOf[Float].toDouble
+    case DoubleType => (v: Any) => v.asInstanceOf[Double]
+    case d: DecimalType => (v: Any) => v.asInstanceOf[Decimal].toDouble
+    case t =>
+      (_: Any) => throw new IllegalStateException(
+        s"Unexpected data type ${t.catalogString} for rank value")
+  }
+
+  protected def getRank(buffer: BaseQuantileSketchImpl, v: Double): Any = {
+    if (!buffer.isEmpty) {
+      buffer.getRank(v)
+    } else {
+      null
+    }
+  }
+
+  @transient private[this] lazy val getOutputRank = {
+    (ar: Any, v: Any) => try {
+      val sketch = QuantileSketch(implName, ar.asInstanceOf[Array[Byte]])
+      getRank(sketch, toDouble(v))
+    } catch {
+      case NonFatal(_) =>
+        logWarning("Illegal input bytes found, so cannot update " +
+          s"an immediate $implName sketch data.")
+        null
+    }
+  }
+
+  override def nullSafeEval(ar: Any, v: Any): Any = getOutputRank(ar, v)
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val rf = ctx.addReferenceObj("getRank", getOutputRank,
+      classOf[(Any, Any) => Any].getCanonicalName)
+    val rank = ctx.freshName("rank")
+    nullSafeCodeGen(ctx, ev, (ar, v) => {
+      s"""
+         |Object $rank = $rf.apply($ar, $v);
+         |if ($rank != null) {
+         |  ${ev.value} = ((Double) $rank).doubleValue();
          |} else {
          |  ${ev.isNull} = true;
          |}

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/quantileSketches.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/quantileSketches.scala
@@ -50,7 +50,7 @@ object QuantileSketch {
   def apply(name: String): BaseQuantileSketchImpl = name.toUpperCase(Locale.ROOT) match {
     case tpe if tpe == KLL.toString =>
       val k = SQLConf.get.quantileSketchKInKll
-      val impl = new jKllFloatsSketch(k)
+      val impl = jKllFloatsSketch.newHeapInstance(k)
       new KllFloatsSketchImpl(impl)
     case tpe if tpe == REQ.toString =>
       val k = SQLConf.get.quantileSketchKInReq

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/shims.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/shims.scala
@@ -39,6 +39,8 @@ object DataSketches {
     expression[CombineQuantileSketches]("approx_percentile_combine"),
     expression[QuantileFromSketchState]("approx_percentile_estimate"),
     expression[PmfFromSketchState]("approx_pmf_estimate"),
+    expression[RankFromData]("approx_rank_ex"),
+    expression[RankFromSketchState]("approx_rank_estimate"),
 
     // Frequent item sketches
     expression[FreqItemSketches]("approx_freqitems"),

--- a/src/test/scala/org/apache/spark/sql/ApproximateQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/ApproximateQuerySuite.scala
@@ -49,6 +49,19 @@ class ApproximateQuerySuite extends QueryTest with SharedSparkSession with SQLTe
     }
   }
 
+  test("approx_rank_ex basic tests") {
+    Seq("KLL", "REQ").foreach { impl =>
+      withSQLConf(DataSketchConf.QUANTILE_SKETCH_IMPL.key -> impl) {
+        val df = spark.sql(
+          s"""
+             |SELECT approx_rank_ex(c, 1.0), approx_rank_ex(c, 4.0)
+             |  FROM VALUES (1.0), (2.0), (3.0), (4.0) AS t(c);
+           """.stripMargin)
+        checkAnswer(df, Row(0.25, 1.0))
+      }
+    }
+  }
+
   test("approx_percentile_ex should keep an input type in output") {
     val testTypes = Seq(("TINYINT", ByteType), ("INT", IntegerType), ("LONG", LongType),
       ("FLOAT", FloatType), ("DOUBLE", DoubleType), ("DECIMAL(10, 0)", DecimalType.IntDecimal))
@@ -174,6 +187,34 @@ class ApproximateQuerySuite extends QueryTest with SharedSparkSession with SQLTe
            """.stripMargin)
       }.getMessage()
       assert(errMsg3.contains("Percentage(s) must be between 0.0 and 1.0"))
+    }
+  }
+
+  test("approx_rank_estimate basic tests") {
+    import org.apache.spark.sql.functions._
+    import testImplicits._
+
+    withTempView("t") {
+      spark.sql(
+        s"""
+           |CREATE TEMPORARY VIEW t AS SELECT * FROM VALUES
+           |  (1.0),
+           |  (2.0),
+           |  (3.0),
+           |  (4.0)
+           |AS t(v);
+         """.stripMargin)
+
+      val summaries = spark.table("t")
+        .agg(expr("approx_percentile_accumulate(v) AS summaries"))
+
+      val merged = summaries.selectExpr("approx_percentile_combine(summaries) AS merged")
+
+      val df1 = merged.selectExpr("approx_rank_estimate(merged, 1.0)")
+      val df2 = merged.selectExpr("approx_rank_estimate(merged, 4.0)")
+
+      checkAnswer(df1, Row(0.25))
+      checkAnswer(df2, Row(1.0))
     }
   }
 


### PR DESCRIPTION
For percentile metrics, in order to scale things better we likely have to use datasketch to implement it. However currently there is no spark implementation for the function getRank (https://apache.github.io/datasketches-python/main/quantiles/req.html#datasketches.req_ints_sketch.get_rank), this PR added it and also made relative changes to make it compatible with Spark 3.5

I implemented two functions in spark sql,
"approx_rank_ex" takes numeric column as input
"approx_rank_estimate" takes sketch binary as input, more details in the readme

output by running
```
SELECT
    company_id,
    experiment_name,
    exposure_hash_no_group,
    metric_hash,
    approx_rank_ex(r1v, 3.0) rank
FROM
    icefireonni_prod_us_central1.openai.temp_rollup_merged_aggregated_rollup_20251109_all_metrics_4
GROUP BY ALL;
```

<img width="1301" height="591" alt="image" src="https://github.com/user-attachments/assets/d54bd43c-4d55-4208-a45b-fa300ec4db25" />


Tested approx_percentile_ex as well
